### PR TITLE
Link from docs to repository

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # ChunkSplitters.jl
 
-ChunkSplitters facilitate the splitting of the workload of parallel
+[ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl) facilitate the splitting of the workload of parallel
 jobs independently on the number of threads that are effectively available. It allows for a finer, lower level, control
 of the load of each task.
 


### PR DESCRIPTION
Sometimes, people may find the documentation first and then want to look at the source code on GitHub. It's nice if there is a direct link.