### PR TITLE
Improve docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,11 +1,8 @@
 # ChunkSplitters.jl
 
-[ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl) facilitate the splitting of the workload of parallel
-jobs independently on the number of threads that are effectively available. It allows for a finer, lower level, control
-of the load of each task.
+[ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl) facilitates the splitting of a given list of work items (of potentially uneven workload) into chunks that can be readily used for parallel processing. Operations on these chunks can, for example, be parallelized with Julia's multithreading tools, where separate tasks are created for each chunk. Compared to naive parallelization, ChunkSplitters.jl therefore effectively allows for more fine-grained control of the composition and workload of each parallel task.
 
-The way chunks are indexed is also recommended for guaranteeing that the workload if completely thread safe 
-(without the use `threadid()` - see [here](https://juliafolds.github.io/FLoops.jl/dev/explanation/faq/#faq-state-threadid)). 
+Working with chunks and their respective indices also improves thread-safety compared to a naive approach based on `threadid()` indexing (see [PSA: Thread-local state is no longer recommended](https://julialang.org/blog/2023/07/PSA-dont-use-threadid/)). 
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,17 +19,13 @@ The main interface is the `chunks` iterator:
 chunks(array::AbstractArray, nchunks::Int, type::Symbol=:batch)
 ```
 
-This iterator returns a `Tuple{UnitRange,Int}` with the range of indices of `array`
-to be iterated for each given chunk. If `type == :batch`, the ranges are consecutive. If `type == :scatter`, the range
-is scattered over the array. 
+This iterator returns a `Tuple{UnitRange,Int}` which indicates the range of indices of the input `array` for each given chunk and the index of the latter. If `type == :batch`, the ranges are consecutive. If `type == :scatter`, the range is scattered over the array.
 
-The chunking types are illustrated in the figure below: 
+The different chunking variants are illustrated in the following figure: 
 
 ![splitter types](./assets/splitters.svg)
 
-In the `:batch` type, the tasks are associated to each thread until the fraction of the workload of that thread is 
-complete. In the `:scatter` type, the tasks are assigned in an alternating fashion. If the workload is uneven and
-correlated with its position in the input array, the `:scatter` option will be more efficient. 
+For `type=:batch`, each chunk is "filled up" one after another with work items such that all chunks hold the same number of work items (as far as possible). For `type=:scatter`, the work items are assigned to chunks in a round-robin fashion. As shown below, this way of chunking can be beneficial if the workload (i.e. the computational weight) for different items is uneven. 
 
 ## Example
 


### PR DESCRIPTION
As promised in #8, I made my pass over the docs. Let me know what you think!

Open things to do/decide:

* The image needs to be improved (see #8). I'll leave that to you.
* I think the entire [Lower-level chunks function](https://m3g.github.io/ChunkSplitters.jl/v1.0/#Lower-level-chunks-function) section is unnecessarily verbose. More importantly, I think that the variant `chunks(array::AbstractArray, ichunk::Int, nchunks::Int, type::Symbol=:batch)` is a misnomer anyways, because it doesn't return *chunks* but just a single *chunk*. It is essentially a *getchunk* function and I wonder why it isn't named this way. For now, I've left it as is and leave the improvement of this API and the corresponding docs section for a future PR (not necessarily by myself).

Close #8 