### PR TITLE
fix small typo in error message

### DIFF
--- a/src/ChunkSplitters.jl
+++ b/src/ChunkSplitters.jl
@@ -67,7 +67,7 @@ end
 # Constructor for the chunks
 function chunks(x::AbstractArray; n::Int, split::Symbol=:batch)
     n >= 1 || throw(ArgumentError("n must be >= 1"))
-    (split in split_types) || throw(ArgumentError("split must be one of $split"))
+    (split in split_types) || throw(ArgumentError("split must be one of $split_types"))
     Chunk{typeof(x)}(x, min(length(x), n), split)
 end
 


### PR DESCRIPTION
Just a quick fix of a Typo.
Was giving the following error message:

```julia
julia> using ChunkSplitters

julia> x = randn(10);

julia> chunks(x; n=4, split=:nonsense)
ERROR: ArgumentError: split must be one of nonsense
Stacktrace:
 [1] #chunks#1
   @ ChunkSplitters ~/.julia/dev/ChunkSplitters/src/ChunkSplitters.jl:70 [inlined]
 [2] top-level scope
   @ REPL[8]:1
```